### PR TITLE
fix php8 deprecated notice

### DIFF
--- a/src/settings.php
+++ b/src/settings.php
@@ -17,6 +17,8 @@ class Settings {
 
 	private $options = null;
 
+	private $checkboxes = [];
+
 	public function __construct() {
 		$this->checkboxes = [
 			[


### PR DESCRIPTION
Fixes php8 related deprected notice. See issue: https://github.com/valu-digital/wp-graphql-lock/issues/6